### PR TITLE
Prepare dogu with released version 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV SCM_HOME=/var/lib/scm \
     # mark as webapp for nginx
     SERVICE_8080_TAGS="webapp" \
     SERVICE_8080_NAME="scm" \
-    SCM_PKG_URL=https://maven.scm-manager.org/nexus/service/local/repositories/releases/content/sonia/scm/scm-server/2.0.0-rc8/scm-server-2.0.0-rc8-app.tar.gz
+    SCM_PKG_URL=https://packages.scm-manager.org/repository/releases/sonia/scm/packaging/unix/2.0.0/unix-2.0.0-app.tar.gz
 
 ## install scm-server
 RUN set -x \
@@ -21,8 +21,8 @@ RUN set -x \
     && cd /tmp \
     # download scm-script-plugin & scm-cas-plugin
     && mkdir ${SCM_REQUIRED_PLUGINS} \
-    && curl --fail -Lks https://maven.scm-manager.org/nexus/service/local/repositories/plugin-releases/content/sonia/scm/plugins/scm-script-plugin/2.0.0-rc2/scm-script-plugin-2.0.0-rc2.smp -o ${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp \
-    && curl --fail -Lks https://maven.scm-manager.org/nexus/service/local/repositories/plugin-releases/content/sonia/scm/plugins/scm-cas-plugin/2.0.0-rc5/scm-cas-plugin-2.0.0-rc5.smp -o ${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp \
+    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-script-plugin/2.0.0/scm-script-plugin-2.0.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp \
+    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-cas-plugin/2.0.0/scm-cas-plugin-2.0.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp \
     # cleanup
     && rm -rf /tmp/* /var/cache/apk/* \
     # set mercurial system ca-certificates

--- a/dogu.json
+++ b/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "itz-bund/scm",
-  "Version": "2.0.0-43",
+  "Version": "2.0.0-44",
   "DisplayName": "SCM-Manager",
   "Description": "The easiest way to share and manage your Git, Mercurial and Subversion repositories over http.",
   "Category": "Development Apps",

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -13,7 +13,7 @@ echo Found old version "${version_parts[0]}"-"${version_parts[1]}"
 
 # When the old dogu version is less then 2.0.0-31, we have to remove the old plugin folder
 if [ "${version_parts[0]}" == "2.0.0" ]; then
-  MINOR_VERSION_DELETE_PLUGINS=43
+  MINOR_VERSION_DELETE_PLUGINS=44
   if [ "${version_parts[1]}" -lt "${MINOR_VERSION_DELETE_PLUGINS}" ]; then
     echo "Found old version less 2.0.0-${MINOR_VERSION_DELETE_PLUGINS}. Creating marker file."
     touch /var/lib/scm/plugins/delete_on_update

--- a/resources/pre-upgrade.sh
+++ b/resources/pre-upgrade.sh
@@ -13,7 +13,7 @@ echo Found old version "${version_parts[0]}"-"${version_parts[1]}"
 
 # When the old dogu version is less then 2.0.0-31, we have to remove the old plugin folder
 if [ "${version_parts[0]}" == "2.0.0" ]; then
-  MINOR_VERSION_DELETE_PLUGINS=31
+  MINOR_VERSION_DELETE_PLUGINS=43
   if [ "${version_parts[1]}" -lt "${MINOR_VERSION_DELETE_PLUGINS}" ]; then
     echo "Found old version less 2.0.0-${MINOR_VERSION_DELETE_PLUGINS}. Creating marker file."
     touch /var/lib/scm/plugins/delete_on_update

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -36,6 +36,7 @@ fi
 
 # delete outdated plugins
 if [ -a "${SCM_DATA}/plugins/delete_on_update" ];  then
+  ls -1 "${SCM_DATA}/plugins/scm-*-plugin" > "${SCM_DATA}/installed_plugins_before_update.lst"
   rm -rf "${SCM_DATA}/plugins"
 fi
 
@@ -44,14 +45,14 @@ start_scm_server () {
   if ! [ -d "${SCM_DATA}/plugins" ];  then
     mkdir "${SCM_DATA}/plugins"
   fi
-  if { ! [ -d "${SCM_DATA}/plugins/scm-cas-plugin" ] || [ -a "${SCM_DATA}/plugins/scm-cas-plugin/uninstall" ] ; } && ! [ -a "${SCM_DATA}/plugins/scm-cas-plugin.smp" ] ;  then
+#  if { ! [ -d "${SCM_DATA}/plugins/scm-cas-plugin" ] || [ -a "${SCM_DATA}/plugins/scm-cas-plugin/uninstall" ] ; } && ! [ -a "${SCM_DATA}/plugins/scm-cas-plugin.smp" ] ;  then
     echo "Reinstalling scm-cas-plugin from default plugin folder"
     cp "${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp" "${SCM_DATA}/plugins"
-  fi
-  if { ! [ -d "${SCM_DATA}/plugins/scm-script-plugin" ] || [ -a "${SCM_DATA}/plugins/scm-script-plugin/uninstall" ] ; } && ! [ -a "${SCM_DATA}/plugins/scm-script-plugin.smp" ] ;  then
+#  fi
+#  if { ! [ -d "${SCM_DATA}/plugins/scm-script-plugin" ] || [ -a "${SCM_DATA}/plugins/scm-script-plugin/uninstall" ] ; } && ! [ -a "${SCM_DATA}/plugins/scm-script-plugin.smp" ] ;  then
     echo "Reinstalling scm-script-plugin from default plugin folder"
     cp "${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp" "${SCM_DATA}/plugins"
-  fi
+#  fi
 
   /opt/scm-server/bin/scm-server
 }

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -106,6 +106,16 @@ if (isFirstStart()) {
     plugins.addAll(defaultPlugins)
 }
 
+File pluginListFile = new File(sonia.scm.SCMContext.getContext().getBaseDirectory(), "installed_plugins_before_update.lst")
+if (pluginListFile.exists()) {
+    def reader = pluginListFile.newReader()
+    def line
+    while ((line = reader.readLine()) != null) {
+        System.out.println("Add previously installed plugin '${line}'");
+        plugins.add(line)
+    }
+}
+
 def pluginManager = injector.getInstance(PluginManager.class);
 def available = pluginManager.getAvailable();
 def installed = pluginManager.getInstalled();

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -25,7 +25,8 @@ def defaultPlugins = [
     "scm-landingpage-plugin",
 ];
 
-def plugins = [];
+def plugins = []
+def pluginsFromOldInstallation = []
 
 // methods
 
@@ -113,6 +114,7 @@ if (pluginListFile.exists()) {
     while ((line = reader.readLine()) != null) {
         System.out.println("Add previously installed plugin '${line}'");
         plugins.add(line)
+        pluginsFromOldInstallation.add(line)
     }
 }
 
@@ -128,9 +130,11 @@ for (def name : plugins) {
             System.out.println("Cannot install missing plugin ${name}. No available plugin found!");
         } else {
             System.out.println("install missing plugin ${availableInformation.name} in version ${availableInformation.version}");
+            pluginsFromOldInstallation.remove(name)
             restart |= installPlugin(pluginManager, name)
         }
     } else {
+        pluginsFromOldInstallation.remove(name)
         System.out.println("plugin ${name} already installed.");
     }
 }
@@ -149,6 +153,15 @@ if (Boolean.valueOf(getValueFromEtcd("/config/scm/update_plugins").toString())) 
     }
 } else {
     System.out.println("skipping plugin update step");
+}
+
+if (pluginListFile.exists()) {
+    if (pluginsFromOldInstallation.isEmpty()) {
+        println "Deleting file with plugins from old installation; all plugins have been installed again."
+        pluginListFile.delete()
+    } else {
+        println "Not all plugins from old installation could be installed; keeping list to try again next time."
+    }
 }
 
 if (restart){


### PR DESCRIPTION
Due to the change in the storage API prior to 2.0.0, we have
to delete all plugins once and reinstall them again. Therefore
we create a list of all installed plugins before we delete them
and try to reinstall them on restart.