### PR TITLE
Add etcd key for default plugins

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -19,6 +19,11 @@
     "Optional": true
   },
   {
+    "Name": "additional_plugins",
+    "Description": "Comma separated list of plugin names to install on start. Uninstalled plugins will also be installed again, since they are defined as default.",
+    "Optional": true
+  },
+  {
     "Name": "update_plugins",
     "Description": "Set to 'true' to install available plugin updates on startup",
     "Optional": true

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -31,7 +31,7 @@ def pluginsFromOldInstallation = []
 // methods
 
 def addMissingDefaultPluginsFromEtcd(plugins){
-    def etcdValue = getValueFromEtcd("additional_plugins");
+    def etcdValue = getValueFromEtcd("/config/scm/additional_plugins");
     if (etcdValue != null) {
         def additionalPlugins = etcdValue.split(",");
         System.out.println("Following plugins must be installed: ${additionalPlugins}");

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -30,6 +30,21 @@ def pluginsFromOldInstallation = []
 
 // methods
 
+def addMissingDefaultPluginsFromEtcd(plugins){
+    def etcdValue = getValueFromEtcd("additional_plugins");
+    if (etcdValue != null) {
+        def additionalPlugins = etcdValue.split(",");
+        System.out.println("Following plugins must be installed: ${additionalPlugins}");
+
+        for (def plugin : additionalPlugins) {
+            if (!plugins.contains(plugin)) {
+                System.out.println("add missing default plugin to installation queue: ${plugin}");
+                plugins.add(plugin)
+            }
+        }
+    }
+}
+
 def isDoguInstalled(name){
 	String ip = new File("/etc/ces/node_master").getText("UTF-8").trim();
 	URL url = new URL("http://${ip}:4001/v2/keys/dogu/${name}/current");
@@ -106,6 +121,8 @@ if (isFirstStart()) {
     System.out.println("First start detected; installing default plugins.");
     plugins.addAll(defaultPlugins)
 }
+
+addMissingDefaultPluginsFromEtcd(plugins)
 
 File pluginListFile = new File(sonia.scm.SCMContext.getContext().getBaseDirectory(), "installed_plugins_before_update.lst")
 if (pluginListFile.exists()) {

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -36,7 +36,8 @@ def addMissingDefaultPluginsFromEtcd(plugins){
         def additionalPlugins = etcdValue.split(",");
         System.out.println("Following plugins must be installed: ${additionalPlugins}");
 
-        for (def plugin : additionalPlugins) {
+        for (def p : additionalPlugins) {
+            def plugin = p.trim();
             if (!plugins.contains(plugin)) {
                 System.out.println("add missing default plugin to installation queue: ${plugin}");
                 plugins.add(plugin)


### PR DESCRIPTION
Add new etcd key `scm_plugins_default`. It expects a comma separated list of scm-plugin names. This default plugins will be installed on each start if they are missing.