### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -38,6 +38,22 @@
       "Name": "update_plugins",
       "Description": "Set to 'true' to install available plugin updates on startup",
       "Optional": true
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 1200m of memory for SCM.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description": "Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "ExposedPorts": [{

--- a/dogu.json
+++ b/dogu.json
@@ -54,6 +54,24 @@
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
       }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the SCM process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for SCM: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the SCM process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for SCM: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
     }
   ],
   "ExposedPorts": [{

--- a/resources/CHANGELOG.md
+++ b/resources/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added the ability to configure the memory limits with `cesapp edit-config`
-- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf` (#29)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the SCM process inside the container via `cesapp edit-conf` (#29)

--- a/resources/CHANGELOG.md
+++ b/resources/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Added the ability to configure the memory limits with `cesapp edit-config`
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf` (#29)

--- a/resources/etc/default/scm-server
+++ b/resources/etc/default/scm-server
@@ -7,3 +7,7 @@ EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.skipAdminCreation=true"
 EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.lifecycle.restart-strategy=exit"
 EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.restart.exit-code=42"
 EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.restart-migration.wait=1000"
+if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MaxRAMPercentage=85.0"
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MinRAMPercentage=50.0"
+fi

--- a/resources/etc/default/scm-server
+++ b/resources/etc/default/scm-server
@@ -8,6 +8,11 @@ EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.lifecycle.restart-strategy
 EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.restart.exit-code=42"
 EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dsonia.scm.restart-migration.wait=1000"
 if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
-  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MaxRAMPercentage=85.0"
-  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MinRAMPercentage=50.0"
+  # Retrieve configurable java limits from etcd, valid default values exist
+  MEMORY_LIMIT_MAX_PERCENTAGE=$(doguctl config "container_config/java_max_ram_percentage")
+  MEMORY_LIMIT_MIN_PERCENTAGE=$(doguctl config "container_config/java_min_ram_percentage")
+
+  echo "Setting memory limits to MaxRAMPercentage: ${MEMORY_LIMIT_MAX_PERCENTAGE} and MinRAMPercentage: ${MEMORY_LIMIT_MIN_PERCENTAGE}..."
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}"
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE}"
 fi

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -1,7 +1,7 @@
 file:
   /etc/default/scm-server:
     exists: true
-    size: 935
+    size: 1385
     owner: root
     group: root
     filetype: file

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -1,7 +1,7 @@
 file:
   /etc/default/scm-server:
     exists: true
-    size: 703
+    size: 935
     owner: root
     group: root
     filetype: file


### PR DESCRIPTION
Fixes #29

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the SCM-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0