### PR TITLE
Add font ttf-dejavu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add font ttf-dejavu ([#32](https://github.com/cloudogu/scm/pull/32))
 
 ## [2.12.0-1]
 ### Changed
@@ -12,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to configure the memory limits with `cesapp edit-config`
 - Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the SCM process inside the container via `cesapp edit-conf` (#29)
 - SCM-Manager Version update to 2.12.0 ([Changelog](https://github.com/scm-manager/scm-manager/blob/2.12.0/CHANGELOG.md))
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV SCM_HOME=/var/lib/scm \
 
 ## install scm-server
 RUN set -x \
-    && apk add --no-cache mercurial jq unzip \
+    && apk add --no-cache ttf-dejavu mercurial jq unzip \
     && curl --fail  -Lks ${SCM_PKG_URL} -o /tmp/scm-server.tar.gz \
     && echo "${SCM_PKG_SHA256} */tmp/scm-server.tar.gz" | sha256sum -c - \
     && addgroup -S -g 1000 scm \


### PR DESCRIPTION
Add font ttf-dejavu to image, in order to fix plugins which require a font to render graphics, such as the markdown-plantuml plugin.