### PR TITLE
Add config option for log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Configuration for loglevel of SCM-Manager core classes ([#33](https://github.com/cloudogu/scm/pull/33))
+
 ## [2.13.0-1]
 ### Added
 - Add font ttf-dejavu ([#32](https://github.com/cloudogu/scm/pull/32))

--- a/dogu.json
+++ b/dogu.json
@@ -72,6 +72,22 @@
       "Validation": {
         "Type": "FLOAT_PERCENTAGE_HUNDRED"
       }
+    },
+    {
+      "Name": "logging/root",
+      "Description": "Set the root log level to one of ERROR, WARN, INFO, DEBUG or TRACE. Default is INFO",
+      "Optional": true,
+      "Default": "INFO",
+      "Validation": {
+        "Type": "ONE_OF",
+        "Values": [
+          "WARN",
+          "ERROR",
+          "INFO",
+          "DEBUG",
+          "TRACE"
+        ]
+      }
     }
   ],
   "ExposedPorts": [{

--- a/resources/etc/default/scm-server
+++ b/resources/etc/default/scm-server
@@ -16,3 +16,8 @@ if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ]
   EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}"
   EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -XX:MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE}"
 fi
+
+if [ "$(doguctl config 'logging/root' -d 'empty')" != "empty" ];  then
+  SCM_CORE_LOG_LEVEL=$(doguctl config "logging/root")
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dscm.logging.core.level=${SCM_CORE_LOG_LEVEL}"
+fi

--- a/resources/opt/scm-server/conf/logging.xml
+++ b/resources/opt/scm-server/conf/logging.xml
@@ -7,7 +7,10 @@
     </encoder>
   </appender>
 
-  <logger name="sonia.scm" level="INFO" />
+  <variable name="SCM_CORE_LOG_LEVEL" value="${scm.logging.core.level:-INFO}" />
+
+  <logger name="sonia.scm" level="${SCM_CORE_LOG_LEVEL}" />
+  <logger name="com.cloudogu.scm" level="${SCM_CORE_LOG_LEVEL}" />
   <logger name="sonia.scm.filter.GZipFilter" level="WARN" />
   <logger name="sonia.scm.filter.GZipResponseStream" level="WARN" />
   <logger name="sonia.scm.util.ServiceUtil" level="WARN" />

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -1,7 +1,7 @@
 file:
   /etc/default/scm-server:
     exists: true
-    size: 1385
+    size: 1607
     owner: root
     group: root
     filetype: file


### PR DESCRIPTION
Adds the etcd configuration `logging/root` to set the log level for the core SCM-Manager classes (`sonia.scm` and `com.cloudogu.scm`).