### PR TITLE
Delete old admin group on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Old admin group will be deleted if value is changed in etcd ([#35](https://github.com/cloudogu/scm/pull/35))
+
 ## [2.16.0-1]
 ### Changed
 - Upgrade SCM-Manager to version 2.16.0 ([Changelog](https://github.com/scm-manager/scm-manager/blob/2.16.0/CHANGELOG.md))

--- a/resources/var/tmp/scm/init.script.d/020-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/020-configuration.groovy
@@ -9,8 +9,6 @@ import sonia.scm.security.PermissionAssigner;
 import sonia.scm.security.PermissionDescriptor;
 import sonia.scm.SCMContextProvider;
 
-println("RUNNING NEW CONFIG SCRIPT")
-
 def sh(String cmd) {
   try {
     proc = cmd.execute()
@@ -26,13 +24,13 @@ def sh(String cmd) {
 def getGlobalValueFromEtcd(String key) {
   value = sh("doguctl config --global --default DEFAULT_VALUE ${key}")
   println "reading global etcd value: '${key}' -> '${value}'"
-  return value == "DEFAULT_VALUE"? null: value
+  return value == "DEFAULT_VALUE" ? null : value
 }
 
 def getValueFromEtcd(String key) {
   value = sh("doguctl config --default DEFAULT_VALUE ${key}")
   println "reading etcd value: '${key}' -> '${value}'"
-  return value == "DEFAULT_VALUE"? null: value
+  return value == "DEFAULT_VALUE" ? null : value
 }
 
 def setEtcdValue(String key, String value) {

--- a/resources/var/tmp/scm/init.script.d/020-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/020-configuration.groovy
@@ -3,35 +3,58 @@
 
 import sonia.scm.config.ScmConfiguration;
 import sonia.scm.util.ScmConfigurationUtil;
-import groovy.json.JsonSlurper;
 import sonia.scm.group.Group;
 import sonia.scm.group.GroupManager;
 import sonia.scm.security.PermissionAssigner;
 import sonia.scm.security.PermissionDescriptor;
 import sonia.scm.SCMContextProvider;
 
-// TODO sharing ???
-def getValueFromEtcd(String key){
+println("RUNNING NEW CONFIG SCRIPT")
+
+def sh(String cmd) {
   try {
-    String ip = new File("/etc/ces/node_master").getText("UTF-8").trim();
-    URL url = new URL("http://${ip}:4001/v2/keys/${key}");
-    def json = new JsonSlurper().parseText(url.text)
-    return json.node.value
-  } catch (FileNotFoundException e) {
+    proc = cmd.execute()
+    proc.out.close()
+    proc.waitForOrKill(10000)
+    return proc.text.trim()
+  } catch (Exception e) {
+    e.printStackTrace()
     return null;
+  }
+}
+
+def getGlobalValueFromEtcd(String key) {
+  value = sh("doguctl config --global --default DEFAULT_VALUE ${key}")
+  println "reading global etcd value: '${key}' -> '${value}'"
+  return value == "DEFAULT_VALUE"? null: value
+}
+
+def getValueFromEtcd(String key) {
+  value = sh("doguctl config --default DEFAULT_VALUE ${key}")
+  println "reading etcd value: '${key}' -> '${value}'"
+  return value == "DEFAULT_VALUE"? null: value
+}
+
+def setEtcdValue(String key, String value) {
+  try {
+    println "setting etcd value '${key}' to '${value}'"
+    sh( "doguctl config ${key} ${value}")
+    println "value set successfully"
+  } catch (Exception e) {
+    e.printStackTrace()
   }
 }
 
 def config = injector.getInstance(ScmConfiguration.class);
 config.setNamespaceStrategy("CustomNamespaceStrategy");
 // set base url
-String fqdn = getValueFromEtcd("config/_global/fqdn");
+String fqdn = getGlobalValueFromEtcd("fqdn");
 config.setBaseUrl("https://${fqdn}/scm");
 
 def context = injector.getInstance(SCMContextProvider.class);
 
 // set plugin center url
-String pluginCenterUrl = getValueFromEtcd("config/scm/plugin_center_url");
+String pluginCenterUrl = getValueFromEtcd("plugin_center_url");
 if (pluginCenterUrl != null && !pluginCenterUrl.isEmpty()) {
   config.setPluginUrl(pluginCenterUrl);
 } else if (context.version.contains("SNAPSHOT")) {
@@ -39,8 +62,8 @@ if (pluginCenterUrl != null && !pluginCenterUrl.isEmpty()) {
 }
 
 // set release feed  url
-String disableReleaseFeed = getValueFromEtcd("config/scm/disable_release_feed");
-String releaseFeedUrl = getValueFromEtcd("config/scm/release_feed_url");
+String disableReleaseFeed = getValueFromEtcd("disable_release_feed");
+String releaseFeedUrl = getValueFromEtcd("release_feed_url");
 
 if (disableReleaseFeed != null && disableReleaseFeed.equalsIgnoreCase("true")) {
   config.setReleaseFeedUrl("");
@@ -55,17 +78,35 @@ config.setEnabledUserConverter(true)
 ScmConfigurationUtil.getInstance().store(config);
 
 // set admin group
-String adminGroup = getValueFromEtcd("config/_global/admin_group");
-GroupManager groupManager = injector.getInstance(GroupManager.class);
+String adminGroup = getGlobalValueFromEtcd("admin_group");
+String currentAdminGroup = getValueFromEtcd("admin_group");
 
+GroupManager groupManager = injector.getInstance(GroupManager.class);
+if (adminGroup != currentAdminGroup) {
+  if (currentAdminGroup != null) {
+    println("configured admin group '${adminGroup}' differs from current admin group '${currentAdminGroup}'")
+
+    Group oldGroup = groupManager.get(currentAdminGroup);
+    if (oldGroup != null) {
+      println("deleting current admin group '${currentAdminGroup}'")
+      groupManager.delete(oldGroup);
+    }
+  }
+}
+
+println("checking configured admin group '${adminGroup}'")
 Group group = groupManager.get(adminGroup);
 if (group == null) {
+  println("admin group '${adminGroup}' does not exist; will be created")
   group = new Group("cas", adminGroup);
   group.setExternal(true);
 
   group = groupManager.create(group);
 }
 
+println("setting permission for '${adminGroup}'")
 PermissionAssigner permissionAssigner = injector.getInstance(PermissionAssigner.class);
 PermissionDescriptor descriptor = new PermissionDescriptor("*");
 permissionAssigner.setPermissionsForGroup(adminGroup, Collections.singleton(descriptor));
+
+setEtcdValue("admin_group", adminGroup)


### PR DESCRIPTION
When the global admin group configured in etcd is
changed, this will delete the group configured before.