### PR TITLE
Hide warp menu tooltip before login so that the login button is visible again

### DIFF
--- a/integrationTests/src/test/java/com/cloudogu/e2e/cas/LoginPage.java
+++ b/integrationTests/src/test/java/com/cloudogu/e2e/cas/LoginPage.java
@@ -2,13 +2,10 @@ package com.cloudogu.e2e.cas;
 
 import com.cloudogu.e2e.Page;
 import com.cloudogu.e2e.Required;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class LoginPage extends Page {
 
@@ -23,6 +20,8 @@ public class LoginPage extends Page {
     @Required
     @FindBy(css = "button[name='submit']")
     WebElement submitButton;
+    @FindBy(className = " warp-onboarding")
+    WebElement tooltip;
 
     public LoginPage(WebDriver driver) {
         super(driver);
@@ -36,6 +35,7 @@ public class LoginPage extends Page {
     }
 
     public void login(String username, String password) {
+        tooltip.click();
         usernameField.sendKeys(username);
         passwordField.sendKeys(password);
         submitButton.click();


### PR DESCRIPTION
This fixes the broken e2e tests.