### PR TITLE
Expose temporary directory for server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Configure CAS proxy chains to allow all dogus within fqdn range ([#39](https://github.com/cloudogu/scm/pull/39))
+- Expose temporary directory for server ([#40](https://github.com/cloudogu/scm/pull/40))
 
 ## [2.20.0-1]
 ### Changed

--- a/dogu.json
+++ b/dogu.json
@@ -118,6 +118,13 @@
     "Owner": "1000",
     "Group": "1000",
     "NeedsBackup": true
+  },
+  {
+    "Name": "temp",
+    "Path": "/var/cache",
+    "Owner": "1000",
+    "Group": "1000",
+    "NeedsBackup": false
   }],
   "HealthCheck": {
     "Type": "tcp",

--- a/resources/opt/scm-server/conf/server-config.xml
+++ b/resources/opt/scm-server/conf/server-config.xml
@@ -10,7 +10,7 @@
       <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
     </Call>
   </New>
-  
+
   <Call name="addConnector">
     <Arg>
       <New class="org.eclipse.jetty.server.ServerConnector">
@@ -45,7 +45,7 @@
       <Arg>false</Arg>
     </Call>
     <Set name="tempDirectory">
-      /tmp/scm
+      /var/cache/scm
     </Set>
   </New>
 


### PR DESCRIPTION
To avoid temporary files written to the container, we expose
an explicit temporary directory.