### PR TITLE
Add config to enable workdir cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Upgrade SCM-Manager to version 2.22.0 ([Changelog](https://github.com/scm-manager/scm-manager/blob/2.22.0/CHANGELOG.md))
+
 ### Added
 - Configuration option for workdir cache ([#41](https://github.com/cloudogu/scm/pull/41))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Configuration option for workdir cache ([#41](https://github.com/cloudogu/scm/pull/41))
+
 ## [2.21.0-1]
 ### Changed
 - Configure CAS proxy chains to allow all dogus within fqdn range ([#39](https://github.com/cloudogu/scm/pull/39))

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ENV SCM_HOME=/var/lib/scm \
     # mark as webapp for nginx
     SERVICE_8080_TAGS="webapp" \
     SERVICE_8080_NAME="scm" \
-    SCM_PKG_URL=https://packages.scm-manager.org/repository/releases/sonia/scm/packaging/unix/2.21.0/unix-2.21.0.tar.gz \
-    SCM_PKG_SHA256=cd1a306ab65c79e0b65ac7b50dcf84fdea39cc76309180fce6492f86cd96ce35 \
+    SCM_PKG_URL=https://packages.scm-manager.org/repository/releases/sonia/scm/packaging/unix/2.22.0/unix-2.22.0.tar.gz \
+    SCM_PKG_SHA256=aa9537eb790e7efdefff3a4278d36448e8755ede1b4566d1de226a97e767d712 \
     SCM_CODE_EDITOR_PLUGIN_SHA256=c5d80fa7ab9723fd3d41b8422ec83433bc3376f59850d97a589fe093f5ca8989 \
-    SCM_SCRIPT_PLUGIN_SHA256=9dd0d065e33a1864457ab3506dad05d8c5a11d80abb8529646c2056e4f3ecf6d \
-    SCM_CAS_PLUGIN_SHA256=b6e8f960cdc7f81f73da4acae1b53c87e0855e418f7145c2cd37b98e0e94f008
+    SCM_SCRIPT_PLUGIN_SHA256=07de0736ce324d2154b199b306c156ff74ecf7816638f2c5307bd3cdbd3da7f6 \
+    SCM_CAS_PLUGIN_SHA256=c73674301e4f1f41a901e90b3f1ffd2895426e4b926fd88ac0d26285ef7368c4
 
 ## install scm-server
 RUN set -x \
@@ -28,9 +28,9 @@ RUN set -x \
     && mkdir ${SCM_REQUIRED_PLUGINS} \
     && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-code-editor-plugin/1.0.0/scm-code-editor-plugin-1.0.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-code-editor-plugin.smp \
     && echo "${SCM_CODE_EDITOR_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-code-editor-plugin.smp" | sha256sum -c - \
-    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-script-plugin/2.2.1/scm-script-plugin-2.2.1.smp -o ${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp \
+    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-script-plugin/2.3.0/scm-script-plugin-2.3.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp \
     && echo "${SCM_SCRIPT_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp" | sha256sum -c - \
-    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-cas-plugin/2.3.0/scm-cas-plugin-2.3.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp \
+    && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-cas-plugin/2.3.1/scm-cas-plugin-2.3.1.smp -o ${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp \
     && echo "${SCM_CAS_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp" | sha256sum -c - \
     # cleanup
     && rm -rf /tmp/* /var/cache/apk/* \

--- a/dogu.json
+++ b/dogu.json
@@ -88,6 +88,12 @@
           "TRACE"
         ]
       }
+    },
+    {
+      "Name": "caching/workdir/size",
+      "Description":"Size of cache for working directories used to edit repository content, for example using the editor or the review plugin. To disable cache, clean this value.",
+      "Optional": true,
+      "Default": "5"
     }
   ],
   "ExposedPorts": [{

--- a/resources/etc/default/scm-server
+++ b/resources/etc/default/scm-server
@@ -21,3 +21,8 @@ if [ "$(doguctl config 'logging/root' -d 'empty')" != "empty" ];  then
   SCM_CORE_LOG_LEVEL=$(doguctl config "logging/root")
   EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dscm.logging.core.level=${SCM_CORE_LOG_LEVEL}"
 fi
+
+if [ "$(doguctl config 'caching/workdir/size' -d 'empty')" != "empty" ];  then
+  SCM_WORKDIR_CACHE=$(doguctl config "caching/workdir/size")
+  EXTRA_JVM_ARGUMENTS="$EXTRA_JVM_ARGUMENTS -Dscm.workingCopyPoolSize=${SCM_WORKDIR_CACHE} -Dscm.workingCopyPoolStrategy=sonia.scm.repository.work.SimpleCachingWorkingCopyPool"
+fi

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -1,7 +1,7 @@
 file:
   /etc/default/scm-server:
     exists: true
-    size: 1607
+    size: 1928
     owner: root
     group: root
     filetype: file


### PR DESCRIPTION
Adds the configuration key `caching/workdir/size` to specify the size of the workdir cache introduced with scm-manager/scm-manager#1735. If this key is not set, caching will be disabled.