### PR TITLE
Add service account scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="sebastian.sdorra@cloudogu.com"
 ENV SCM_HOME=/var/lib/scm \
     SCM_REQUIRED_PLUGINS=/opt/scm-server/required-plugins \
     SSL_CERT_FILE=/opt/scm-server/conf/ca-certificates.crt \
+    CES_TOKEN_HEADER=X-CES-Token \
+    CES_TOKEN_CONFIGURATION_KEY=serviceaccount_token \
     # mark as webapp for nginx
     SERVICE_8080_TAGS="webapp" \
     SERVICE_8080_NAME="scm" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV SCM_HOME=/var/lib/scm \
     SCM_PKG_SHA256=78fc3617c828dc465524ab27faacda492c397afa82df828897a3850cffa5d354 \
     SCM_CODE_EDITOR_PLUGIN_SHA256=c5d80fa7ab9723fd3d41b8422ec83433bc3376f59850d97a589fe093f5ca8989 \
     SCM_SCRIPT_PLUGIN_SHA256=07de0736ce324d2154b199b306c156ff74ecf7816638f2c5307bd3cdbd3da7f6 \
-    SCM_CAS_PLUGIN_SHA256=c73674301e4f1f41a901e90b3f1ffd2895426e4b926fd88ac0d26285ef7368c4
+    SCM_CAS_PLUGIN_SHA256=c73674301e4f1f41a901e90b3f1ffd2895426e4b926fd88ac0d26285ef7368c4 \
+    SCM_CES_PLUGIN_SHA256=TODO
 
 ## install scm-server
 RUN set -x \
@@ -34,6 +35,9 @@ RUN set -x \
     && echo "${SCM_SCRIPT_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-script-plugin.smp" | sha256sum -c - \
     && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-cas-plugin/2.3.1/scm-cas-plugin-2.3.1.smp -o ${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp \
     && echo "${SCM_CAS_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-cas-plugin.smp" | sha256sum -c - \
+    # TODO
+    # && curl --fail -Lks https://packages.scm-manager.org/repository/plugin-releases/sonia/scm/plugins/scm-cas-plugin/1.0.0/scm-ces-plugin-1.0.0.smp -o ${SCM_REQUIRED_PLUGINS}/scm-ces-plugin.smp \
+    # && echo "${SCM_CES_PLUGIN_SHA256} *${SCM_REQUIRED_PLUGINS}/scm-ces-plugin.smp" | sha256sum -c - \
     # cleanup
     && rm -rf /tmp/* /var/cache/apk/* \
     # set mercurial system ca-certificates

--- a/dogu.json
+++ b/dogu.json
@@ -103,6 +103,16 @@
   }],
   "ExposedCommands": [
     {
+      "Name": "service-account-create",
+      "Description": "Creates a new service account",
+      "Command": "/create-sa.sh"
+    },
+    {
+      "Name": "service-account-remove",
+      "Description": "Removes a service account",
+      "Command": "/remove-sa.sh"
+    },
+    {
       "Name": "pre-upgrade",
       "Command": "/pre-upgrade.sh"
     },

--- a/resources/create-sa.sh
+++ b/resources/create-sa.sh
@@ -3,16 +3,19 @@ set -o errexit
 set -o pipefail
 
 if [ -z "$1" ]; then
-    echo "usage create-sa.sh servicename [permission]"
+    echo "usage create-sa.sh servicename [ro|rw]"
     exit 1
 fi
 
 SERVICE="$1"
 
-if [ -z "$2" ]; then
+if [ -z "$2" ] || [[ "$2" == "ro" ]]; then
     PERMISSION="repository:read,pull:*"
+elif [[ "$2" == "rw" ]]; then
+    PERMISSION="*"
 else
-    PERMISSION="$2"
+    echo "usage create-sa.sh servicename [ro|rw]"
+    exit 1
 fi
 
 # create random username suffix and password

--- a/resources/create-sa.sh
+++ b/resources/create-sa.sh
@@ -1,32 +1,41 @@
 #!/bin/bash
 set -o errexit
-set -o nounset
 set -o pipefail
 
-{
-    SERVICE="$1"
-    if [ X"${SERVICE}" = X"" ]; then
-        echo "usage create-sa.sh servicename [permission]"
-        exit 1
-    fi
+if [ -z "$1" ]; then
+    echo "usage create-sa.sh servicename [permission]"
+    exit 1
+fi
 
+SERVICE="$1"
+
+if [ -z "$2" ]; then
+    PERMISSION="repository:read,pull:*"
+else
     PERMISSION="$2"
-    if [ X"${PERMISSION}" = X"" ]; then
-        PERMISSION="repository:read,pull:*"
-    fi
+fi
 
-    # create random username suffix and password
-    ID=$(doguctl random -l 6 | tr '[:upper:]' '[:lower:]')
-    USER="${SERVICE}_${ID}"
-    PASSWORD=$(doguctl random)
+# create random username suffix and password
+ID=$(doguctl random -l 6 | tr '[:upper:]' '[:lower:]')
+USER="${SERVICE}_${ID}"
+PASSWORD=$(doguctl random)
 
-    # connection token
-    API_TOKEN=$(doguctl config --encrypted serviceaccount_token)
+# connection token
+API_TOKEN=$(doguctl config --encrypted ${CES_TOKEN_CONFIGURATION_KEY})
 
-    # create user
-    curl -v http://localhost:8081/scm/api/v2/ces/serviceaccount -H "X-CES-Token: ${API_TOKEN}" --data '{"username":"'${USER}'","password":"'${PASSWORD}'", "permission":"'${PERMISSION}'"}' -H "Content-Type: application/vnd.scmm-serviceaccount+json"
+# create user
+STATUSCODE=$(curl --silent http://localhost:8080/scm/api/v2/users -H "${CES_TOKEN_HEADER}: ${API_TOKEN}" --data '{"name":"'${USER}'","displayName":"CES Serviceaccount","active":true,"password":"'${PASSWORD}'"}' -H "Content-Type: application/vnd.scmm-user+json;v=2" --write-out "%{http_code}")
+if [ $STATUSCODE -ne 201 ]; then
+    echo failed creating user: $STATUSCODE
+    exit 2
+fi
 
-} >/dev/null 2>&1
+# create permission
+STATUSCODE=$(curl --silent http://localhost:8080/scm/api/v2/users/${USER}/permissions -H "${CES_TOKEN_HEADER}: ${API_TOKEN}" --data '{"permissions":["'${PERMISSION}'"]}' -H "Content-Type: application/vnd.scmm-permissionCollection+json;v=2" -X PUT --write-out "%{http_code}")
+if [ $STATUSCODE -ne 204 ]; then
+    echo failed setting permission: $STATUSCODE
+    exit 3
+fi
 
 # print details
 echo "username: ${USER}"

--- a/resources/create-sa.sh
+++ b/resources/create-sa.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+{
+    SERVICE="$1"
+    if [ X"${SERVICE}" = X"" ]; then
+        echo "usage create-sa.sh servicename [permission]"
+        exit 1
+    fi
+
+    PERMISSION="$2"
+    if [ X"${PERMISSION}" = X"" ]; then
+        PERMISSION="repository:read,pull:*"
+    fi
+
+    # create random username suffix and password
+    ID=$(doguctl random -l 6 | tr '[:upper:]' '[:lower:]')
+    USER="${SERVICE}_${ID}"
+    PASSWORD=$(doguctl random)
+
+    # connection token
+    API_TOKEN=$(doguctl config --encrypted serviceaccount_token)
+
+    # create user
+    curl -v http://localhost:8081/scm/api/v2/ces/serviceaccount -H "X-CES-Token: ${API_TOKEN}" --data '{"username":"'${USER}'","password":"'${PASSWORD}'", "permission":"'${PERMISSION}'"}' -H "Content-Type: application/vnd.scmm-serviceaccount+json"
+
+} >/dev/null 2>&1
+
+# print details
+echo "username: ${USER}"
+echo "password: ${PASSWORD}"

--- a/resources/remove-sa.sh
+++ b/resources/remove-sa.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+
+if [ -z "$1" ]; then
+    echo "usage create-sa.sh servicename"
+    exit 1
+fi
+
+SERVICE="$1"
+
+# connection token
+API_TOKEN=$(doguctl config --encrypted ${CES_TOKEN_CONFIGURATION_KEY})
+
+# read users
+USERMATCH=${SERVICE}_[a-zA-Z0-9]{6}
+
+for username in $(curl --silent http://localhost:8080/scm/api/v2/users\?fields=_embedded.users.name\&pageSize=999 -H "${CES_TOKEN_HEADER}: ${API_TOKEN}" | jq -r '._embedded.users | .[] | .name')
+do
+  if [[ $username =~ $USERMATCH ]]
+  then
+    echo DELETE $username
+    curl --silent http://localhost:8080/scm/api/v2/users/$username -X DELETE -H "${CES_TOKEN_HEADER}: ${API_TOKEN}"
+  fi
+done

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -42,7 +42,7 @@ fi
 
 # create api token for service account
 API_TOKEN=$(doguctl random)
-doguctl config --encrypted serviceaccount_token "${API_TOKEN}"
+doguctl config --encrypted ${CES_TOKEN_CONFIGURATION_KEY} "${API_TOKEN}"
 
 start_scm_server () {
   # install required plugins

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -40,6 +40,10 @@ if [ -f "${SCM_DATA}/plugins/delete_on_update" ];  then
   rm -rf "${SCM_DATA}/plugins"
 fi
 
+# create api token for service account
+API_TOKEN=$(doguctl random)
+doguctl config --encrypted serviceaccount_token "${API_TOKEN}"
+
 start_scm_server () {
   # install required plugins
   if ! [ -d "${SCM_DATA}/plugins" ];  then

--- a/spec/goss/goss.yaml
+++ b/spec/goss/goss.yaml
@@ -70,6 +70,18 @@ file:
     group: root
     filetype: file
     contains: []
+  /create-sa.sh:
+    exists: true
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /remove-sa.sh:
+    exists: true
+    owner: root
+    group: root
+    filetype: file
+    contains: []
   /var/lib/scm:
     exists: true
     owner: scm


### PR DESCRIPTION
Adds two scripts, `create-sa.sh` and `remove-sa.sh` that can be used to create service accounts. This is done using the REST API of SCM-Manager. For authentication, we introduce a new "CES Token" that will be stored in etcd.

This requires the [CES plugin](https://github.com/scm-manager/scm-ces-plugin).