### PR TITLE
Make new URLs configurable

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -36,6 +36,11 @@
             "Optional": true
         },
         {
+            "Name": "plugin_center_authentication_url",
+            "Description": "URL of SCM-Manager Plugin Center authentication service. To delete the URL and hence disable plugin center authentication, set this to 'none'.",
+            "Optional": true
+        },
+        {
             "Name": "release_feed_url",
             "Description": "URL of SCM-Manager release RSS feed",
             "Optional": true

--- a/resources/var/tmp/scm/init.script.d/020-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/020-configuration.groovy
@@ -57,6 +57,17 @@ if (pluginCenterUrl != null && !pluginCenterUrl.isEmpty()) {
   config.setPluginUrl(pluginCenterUrl);
 } else if (context.version.contains("SNAPSHOT")) {
   config.setPluginUrl("https://oss.cloudogu.com/jenkins/job/scm-manager-github/job/ci-plugin-snapshot/job/master/lastSuccessfulBuild/artifact/plugins/plugin-center.json");
+  config.setPluginAuthUrl("");
+}
+
+String pluginCenterAuthenticationUrl = getValueFromEtcd("plugin_center_authentication_url");
+if (pluginCenterAuthenticationUrl != null) {
+  if ("none".equalsIgnoreCase(pluginCenterAuthenticationUrl)) {
+    println("deactivating plugin center authentication")
+    config.setPluginAuthUrl("");
+  } else if (!pluginCenterAuthenticationUrl.isEmpty()) {
+    config.setPluginAuthUrl(pluginCenterAuthenticationUrl);
+  }
 }
 
 // set release feed  url


### PR DESCRIPTION
This adds configuration options for the cesapp for the plugin center
authentication URL and the feedback URL. Hence it is not possible to
set explicit empty configuration values using the cesapp, one can now
use 'none' to disable plugin center authentication and feedback by
setting the url values to empty strings.

Additionally we disable the plugin center authentication for SNAPSHOT
releases, because authentication does not make any sense for json
plugin center files.