### PR TITLE
Make login info and alerts URLs configurable

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -46,6 +46,16 @@
             "Optional": true
         },
         {
+            "Name": "login_info_url",
+            "Description": "URL for the login info. To delete the URL and hence disable the login info feature, set this to 'none'",
+            "Optional": true
+        },
+        {
+            "Name": "alerts_url",
+            "Description:": "URL for alerts in SCM-Manager. To delete the URL and hence disable the alerts feature, set this to 'none'",
+            "Optional": true
+        },
+        {
             "Name": "disable_release_feed",
             "Description": "If set to 'true', SCM-Manager will not query for new releases",
             "Optional": true

--- a/resources/var/tmp/scm/init.script.d/020-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/020-configuration.groovy
@@ -63,11 +63,31 @@ if (pluginCenterUrl != null && !pluginCenterUrl.isEmpty()) {
 String pluginCenterAuthenticationUrl = getValueFromEtcd("plugin_center_authentication_url");
 if (pluginCenterAuthenticationUrl != null) {
   if ("none".equalsIgnoreCase(pluginCenterAuthenticationUrl)) {
-    println("deactivating plugin center authentication")
+    println("deactivating plugin center authentication");
     config.setPluginAuthUrl("");
   } else if (!pluginCenterAuthenticationUrl.isEmpty()) {
     config.setPluginAuthUrl(pluginCenterAuthenticationUrl);
   }
+}
+
+String loginInfoUrl = getValueFromEtcd("login_info_url");
+if (loginInfoUrl != null) {
+    if ("none".equalsIgnoreCase(loginInfoUrl)) {
+        println("deactivating login info");
+        config.setLoginInfoUrl("");
+    } else if (!loginInfoUrl.isEmpty()) {
+        config.setLoginInfoUrl(loginInfoUrl);
+    }
+}
+
+String alertsUrl = getValueFromEtcd("alerts_url");
+if (alertsUrl != null) {
+    if ("none".equalsIgnoreCase(alertsUrl)) {
+        println("deactivating alerts");
+        config.setAlertsUrl("");
+    } else if (!alertsUrl.isEmpty()) {
+        config.setAlertsUrl(alertsUrl);
+    }
 }
 
 // set release feed  url


### PR DESCRIPTION
This adds configuration options for the cesapp for the login info URL
and the alerts URL. Hence it is not possible to
set explicit empty configuration values using the cesapp, one can now
use 'none' to disable login info and alerts by
setting the url values to empty strings.