### PR TITLE
Remove default plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Removed
+- Default Plugins ([#70](https://github.com/cloudogu/scm/pull/70/files))
+
 ## [2.42.1-1]
 ### Changed
 - Upgrade SCM-Manager to version 2.42.1 ([Changelog](https://github.com/scm-manager/scm-manager/blob/2.42.1/CHANGELOG.md))

--- a/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
+++ b/resources/var/tmp/scm/init.script.d/040-install-plugins.groovy
@@ -4,33 +4,6 @@ import sonia.scm.plugin.PluginManager;
 import groovy.json.JsonSlurper;
 
 // configuration
-def defaultPlugins = [
-    "scm-mail-plugin",
-    "scm-review-plugin",
-    "scm-tagprotection-plugin",
-    "scm-jira-plugin",
-    "scm-activity-plugin",
-    "scm-statistic-plugin",
-    "scm-pathwp-plugin",
-    "scm-branchwp-plugin",
-    "scm-notify-plugin",
-    "scm-authormapping-plugin",
-    "scm-groupmanager-plugin",
-    "scm-pushlog-plugin",
-    "scm-support-plugin",
-    "scm-directfilelink-plugin",
-    "scm-readme-plugin",
-    "scm-editor-plugin",
-    "scm-landingpage-plugin",
-    "scm-repository-template-plugin",
-    "scm-commit-message-checker-plugin",
-    "scm-trace-monitor-plugin",
-    "scm-markdown-plantuml-plugin",
-    "scm-repository-avatar-plugin",
-    "scm-ssl-context-plugin",
-    "scm-repository-mirror-plugin"
-];
-
 def plugins = []
 def pluginsFromOldInstallation = []
 
@@ -135,12 +108,6 @@ if (isDoguInstalled("cockpit")) {
 
 if (isDoguInstalled("gotenberg")) {
     plugins.add("scm-gotenberg-plugin")
-}
-
-// install default plugins
-if (isFirstStart()) {
-    System.out.println("First start detected; installing default plugins.");
-    plugins.addAll(defaultPlugins)
 }
 
 addMissingDefaultPluginsFromEtcd(plugins)


### PR DESCRIPTION
Default plugins should be installed only using
the blueprint mechanism from the ecosystem. With
the old list of default plugins, this was not
really usable, because the old list of default
plugins always installed nearly all plugins
available, so that the user had no way to create
a smaller default set.

So with this, we completely remove the default
plugin list. All necessary plugins like the
legacy plugins for CAS will still be installed by
the dependency checks.