### PR TITLE
Create volume for /tmp

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -239,8 +239,15 @@
             "NeedsBackup": true
         },
         {
-            "Name": "temp",
+            "Name": "cache",
             "Path": "/var/cache",
+            "Owner": "1000",
+            "Group": "1000",
+            "NeedsBackup": false
+        },
+        {
+            "Name": "temp",
+            "Path": "/tmp",
             "Owner": "1000",
             "Group": "1000",
             "NeedsBackup": false


### PR DESCRIPTION
Without this volume it might be possible,
that big temporary files are written in the
docker image which might lead to errors due
to full drives.