### PR TITLE
Setting the correct type of redmine config

### DIFF
--- a/dogu.json
+++ b/dogu.json
@@ -111,7 +111,7 @@
         },
         {
             "Name": "redmine_type",
-            "Description": "Sets which type of redmine is prefered, if both dogus are installed",
+            "Description": "If both, Redmine and EasyRedmine are installed, this sets which instance should be configured",
             "Optional": true,
             "Default": "EASY_REDMINE",
             "Validation": {

--- a/dogu.json
+++ b/dogu.json
@@ -110,6 +110,19 @@
             }
         },
         {
+            "Name": "redmine_type",
+            "Description": "Sets which type of redmine is prefered, if both dogus are installed",
+            "Optional": true,
+            "Default": "EASY_REDMINE",
+            "Validation": {
+                "Type": "ONE_OF",
+                "Values": [
+                    "REDMINE",
+                    "EASY_REDMINE"
+                ]
+            }
+        },
+        {
             "Name": "logging/root",
             "Description": "Set the root log level to one of ERROR, WARN, INFO, DEBUG or TRACE. Default is INFO",
             "Optional": true,

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -78,8 +78,6 @@ try {
   } else if (isRedmineInstalled) {
     configureRedmine(config, fqdn, formattingClass)
   } else {
-    config.setTextFormatting(null)
-    config.setUrl(null)
     println "no redmine dogu is installed"
   }
 

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -10,7 +10,7 @@ def getValueFromEtcd(String key){
 	return json.node.value
 }
 
-def getPreferedRedmine() {
+def getPreferredRedmine() {
   try {
     String preferedRedmine = getValueFromEtcd("/config/scm/redmine_type")
     return preferedRedmine
@@ -65,7 +65,7 @@ try {
 
   def formattingClass = findClass("sonia.scm.redmine.config.TextFormatting")
 
-  String preferedRedmine = getPreferedRedmine()
+  String preferredRedmine = getPreferredRedmine()
   isEasyRedmineInstalled = isDoguInstalled("easyredmine")
   isRedmineInstalled = isDoguInstalled("redmine")
 

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -12,8 +12,8 @@ def getValueFromEtcd(String key){
 
 def getPreferredRedmine() {
   try {
-    String preferedRedmine = getValueFromEtcd("/config/scm/redmine_type")
-    return preferedRedmine
+    String preferredRedmine = getValueFromEtcd("/config/scm/redmine_type")
+    return preferredRedmine
   } catch (FileNotFoundException ex) {
     return "EASY_REDMINE"
   }
@@ -69,11 +69,11 @@ try {
   isEasyRedmineInstalled = isDoguInstalled("easyredmine")
   isRedmineInstalled = isDoguInstalled("redmine")
 
-  if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("EASY_REDMINE")) {
-    println "both dogus installed and easy redmine is prefered"
+  if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("EASY_REDMINE")) {
+    println "both dogus installed and easy redmine is preferred"
     configureEasyRedmine(config, fqdn, formattingClass)
-  } else if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("REDMINE")) {
-    println "both dogus installed and redmine is prefered"
+  } else if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("REDMINE")) {
+    println "both dogus installed and redmine is preferred"
     configureRedmine(config, fqdn, formattingClass)
   } else if (isEasyRedmineInstalled) {
     println "only easy redmine is installed"

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -49,6 +49,36 @@ def configureRedmine(config, fqdn, formattingClass) {
   config.setUrl("https://${fqdn}/redmine")
 }
 
+def shouldEasyRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine) {
+  if (!isEasyRedmineInstalled) {
+    println "easy redmine dogu is not installed"
+    return false
+  }
+
+  if (isRedmineInstalled && preferredRedmine.equals("REDMINE")) {
+    println "redmine is preferred"
+    return false 
+  }
+
+  println "easy redmine configured"
+  return true
+}
+
+def shouldRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine) {
+  if (!isRedmineInstalled) {
+    println "redmine dogu is not installed"
+    return false
+  }
+
+  if (isEasyRedmineInstalled && preferredRedmine.equals("EASY_REDMINE")) {
+    println "easy redmine is preferred"
+    return false 
+  }
+
+  println "redmine configured"
+  return true
+}
+
 try {
   def storeClass = findClass("sonia.scm.redmine.config.RedmineConfigStore")
   def store = injector.getInstance(storeClass);
@@ -69,17 +99,9 @@ try {
   isEasyRedmineInstalled = isDoguInstalled("easyredmine")
   isRedmineInstalled = isDoguInstalled("redmine")
 
-  if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("EASY_REDMINE")) {
-    println "both dogus installed and easy redmine is preferred"
+  if (shouldEasyRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine)) {
     configureEasyRedmine(config, fqdn, formattingClass)
-  } else if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("REDMINE")) {
-    println "both dogus installed and redmine is preferred"
-    configureRedmine(config, fqdn, formattingClass)
-  } else if (isEasyRedmineInstalled) {
-    println "only easy redmine is installed"
-    configureEasyRedmine(config, fqdn, formattingClass)
-  } else if (isRedmineInstalled) {
-    println "only redmine is installed"
+  } else if (shouldRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine)) {
     configureRedmine(config, fqdn, formattingClass)
   } else {
     println "no redmine dogu is installed"

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -10,48 +10,80 @@ def getValueFromEtcd(String key){
 	return json.node.value
 }
 
+def getPreferedRedmine() {
+  try {
+    String preferedRedmine = getValueFromEtcd("/config/scm/redmine_type")
+    return preferedRedmine
+  } catch (FileNotFoundException ex) {
+    return "EASY_REDMINE"
+  }
+}
+
 def findClass(clazzAsString) {
   return Class.forName(clazzAsString, true, Thread.currentThread().getContextClassLoader())
 }
 
 def isDoguInstalled(name){
-    String ip = new File("/etc/ces/node_master").getText("UTF-8").trim();
-    URL url = new URL("http://${ip}:4001/v2/keys/dogu/${name}/current");
-    return url.openConnection().getResponseCode() == 200;
+  String ip = new File("/etc/ces/node_master").getText("UTF-8").trim();
+  URL url = new URL("http://${ip}:4001/v2/keys/dogu/${name}/current");
+  return url.openConnection().getResponseCode() == 200;
+}
+
+def configureEasyRedmine(config, fqdn, formattingClass) {
+  def formatting
+
+  try {
+    formatting = Enum.valueOf(formattingClass, "HTML")
+  } catch (IllegalArgumentException ex) {
+    println "Could not resolve HTML formatting. Set MARKDOWN instead."
+    formatting = Enum.valueOf(formattingClass, "MARKDOWN")
+  }
+
+  config.setTextFormatting(formatting)
+  config.setUrl("https://${fqdn}/easyredmine")
+}
+
+def configureRedmine(config, fqdn, formattingClass) {
+  def formatting = Enum.valueOf(formattingClass, "MARKDOWN")
+  config.setTextFormatting(formatting)
+  config.setUrl("https://${fqdn}/redmine")
 }
 
 try {
-    def storeClass = findClass("sonia.scm.redmine.config.RedmineConfigStore")
-    def store = injector.getInstance(storeClass);
+  def storeClass = findClass("sonia.scm.redmine.config.RedmineConfigStore")
+  def store = injector.getInstance(storeClass);
 
-		String fqdn = getValueFromEtcd("config/_global/fqdn")
+	String fqdn = getValueFromEtcd("config/_global/fqdn")
 
-    def config = store.getConfiguration()
-    if (config.getUrl() == null) {
-      // do not enabled commenting and state changes,
-      // because we need a technical account on redmine before
-      config.setUpdateIssues(false)
-      config.setAutoClose(false)
-    }
-    def formattingClass = findClass("sonia.scm.redmine.config.TextFormatting")
+  def config = store.getConfiguration()
+  if (config.getUrl() == null) {
+    // do not enabled commenting and state changes,
+    // because we need a technical account on redmine before
+    config.setUpdateIssues(false)
+    config.setAutoClose(false)
+  }
 
-    if (isDoguInstalled("easyredmine")) {
-        def formatting
-        try {
-            formatting = Enum.valueOf(formattingClass, "HTML")
-        } catch (IllegalArgumentException ex) {
-            println "Could not resolve HTML formatting. Set MARKDOWN instead."
-            formatting = Enum.valueOf(formattingClass, "MARKDOWN")
-        }
-        config.setTextFormatting(formatting)
-        config.setUrl("https://${fqdn}/easyredmine")
-    } else {
-        def formatting = Enum.valueOf(formattingClass, "MARKDOWN")
-        config.setTextFormatting(formatting)
-        config.setUrl("https://${fqdn}/redmine")
-    }
+  def formattingClass = findClass("sonia.scm.redmine.config.TextFormatting")
 
-    store.storeConfiguration(config)
+  String preferedRedmine = getPreferedRedmine()
+  isEasyRedmineInstalled = isDoguInstalled("easyredmine")
+  isRedmineInstalled = isDoguInstalled("redmine")
+
+  if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("EASY_REDMINE")) {
+    configureEasyRedmine(config, fqdn, formattingClass)
+  } else if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("REDMINE")) {
+    configureRedmine(config, fqdn, formattingClass)
+  } else if (isEasyRedmineInstalled) {
+    configureEasyRedmine(config, fqdn, formattingClass)
+  } else if (isRedmineInstalled) {
+    configureRedmine(config, fqdn, formattingClass)
+  } else {
+    config.setTextFormatting(null)
+    config.setUrl(null)
+    println "no redmine dogu is installed"
+  }
+
+  store.storeConfiguration(config)
 } catch( ClassNotFoundException e ) {
-    println "redmine plugin seems not to be installed"
+  println "redmine plugin seems not to be installed"
 }

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -49,36 +49,6 @@ def configureRedmine(config, fqdn, formattingClass) {
   config.setUrl("https://${fqdn}/redmine")
 }
 
-def shouldEasyRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine) {
-  if (!isEasyRedmineInstalled) {
-    println "easy redmine dogu is not installed"
-    return false
-  }
-
-  if (isRedmineInstalled && preferredRedmine.equals("REDMINE")) {
-    println "redmine is preferred"
-    return false 
-  }
-
-  println "easy redmine configured"
-  return true
-}
-
-def shouldRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine) {
-  if (!isRedmineInstalled) {
-    println "redmine dogu is not installed"
-    return false
-  }
-
-  if (isEasyRedmineInstalled && preferredRedmine.equals("EASY_REDMINE")) {
-    println "easy redmine is preferred"
-    return false 
-  }
-
-  println "redmine configured"
-  return true
-}
-
 try {
   def storeClass = findClass("sonia.scm.redmine.config.RedmineConfigStore")
   def store = injector.getInstance(storeClass);
@@ -99,9 +69,17 @@ try {
   isEasyRedmineInstalled = isDoguInstalled("easyredmine")
   isRedmineInstalled = isDoguInstalled("redmine")
 
-  if (shouldEasyRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine)) {
+  if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("EASY_REDMINE")) {
+    println "both dogus installed and easy redmine is preferred"
     configureEasyRedmine(config, fqdn, formattingClass)
-  } else if (shouldRedmineBeInstalled(isEasyRedmineInstalled, isRedmineInstalled, preferredRedmine)) {
+  } else if (isEasyRedmineInstalled && isRedmineInstalled && preferredRedmine.equals("REDMINE")) {
+    println "both dogus installed and redmine is preferred"
+    configureRedmine(config, fqdn, formattingClass)
+  } else if (isEasyRedmineInstalled) {
+    println "only easy redmine is installed"
+    configureEasyRedmine(config, fqdn, formattingClass)
+  } else if (isRedmineInstalled) {
+    println "only redmine is installed"
     configureRedmine(config, fqdn, formattingClass)
   } else {
     println "no redmine dogu is installed"

--- a/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/080-redmine-configuration.groovy
@@ -70,12 +70,16 @@ try {
   isRedmineInstalled = isDoguInstalled("redmine")
 
   if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("EASY_REDMINE")) {
+    println "both dogus installed and easy redmine is prefered"
     configureEasyRedmine(config, fqdn, formattingClass)
   } else if (isEasyRedmineInstalled && isRedmineInstalled && preferedRedmine.equals("REDMINE")) {
+    println "both dogus installed and redmine is prefered"
     configureRedmine(config, fqdn, formattingClass)
   } else if (isEasyRedmineInstalled) {
+    println "only easy redmine is installed"
     configureEasyRedmine(config, fqdn, formattingClass)
   } else if (isRedmineInstalled) {
+    println "only redmine is installed"
     configureRedmine(config, fqdn, formattingClass)
   } else {
     println "no redmine dogu is installed"


### PR DESCRIPTION
If both types of redmine dogus are installed Easy Redmine gets prefered, unless the user configured the scm dogu property redmine_type with the value "REDMINE".

If only one type of redmine dogu is installed, then the script uses that one.

To test the script use vagrant and this repo: https://github.com/cloudogu/ecosystem
If you have trouble connecting to the ecosystem then uncomment the line `config.vm.network "public_network"`

To install easyredmine dogu, I used this repo: https://github.com/cloudogu/easyredmine