### PR TITLE
Fix handling of different TransportStrategy enums

### DIFF
--- a/resources/var/tmp/scm/init.script.d/050-mail-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/050-mail-configuration.groovy
@@ -14,7 +14,7 @@ def getEmailAddress(){
     try {
       configuredMailAddress = getValueFromEtcd("config/_global/mail_address");
     } catch (FileNotFoundException ex) {
-      println "could not find mail_address configuration in registry"
+      System.out.println "could not find mail_address configuration in registry"
     }
     if (configuredMailAddress != null && configuredMailAddress.length() > 0) {
       return configuredMailAddress;
@@ -34,8 +34,10 @@ def findInstance(clazzAsString) {
 def findSmtpStrategy() {
   try {
     strategyClass = findClass("org.codemonkey.simplejavamail.TransportStrategy");
+    System.out.println "using old SMTP strategy for version 2.x mail plugin configuration";
     return Enum.valueOf(strategyClass, "SMTP_PLAIN");
   } catch (ClassNotFoundException ignored) {
+    System.out.println "could not find configuration for version 2.x mail plugin, using 3.x SMTP strategy";
   }
 
   strategyClass = findClass("sonia.scm.mail.api.ScmTransportStrategy");
@@ -64,5 +66,5 @@ try {
 
   mailContext.store(configuration);
 } catch( ClassNotFoundException e ) {
-  println "mail plugin seems not to be installed"
+  System.out.println "mail plugin seems not to be installed"
 }

--- a/resources/var/tmp/scm/init.script.d/050-mail-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/050-mail-configuration.groovy
@@ -31,6 +31,17 @@ def findInstance(clazzAsString) {
   return injector.getInstance( findClass(clazzAsString) );
 }
 
+def findSmtpStrategy() {
+  try {
+    strategyClass = findClass("org.codemonkey.simplejavamail.TransportStrategy");
+    return Enum.valueOf(strategyClass, "SMTP_PLAIN");
+  } catch (ClassNotFoundException ignored) {
+  }
+
+  strategyClass = findClass("sonia.scm.mail.api.ScmTransportStrategy");
+  return Enum.valueOf(strategyClass, "SMTP");
+}
+
 try {
   def mailContext = findInstance("sonia.scm.mail.api.MailContext");
 
@@ -43,11 +54,10 @@ try {
 
   // TODO unable to resolve class sonia.scm.mail.api.MailConfiguration
   def configClass = findClass("sonia.scm.mail.api.MailConfiguration");
-  def strategyClass = findClass("org.codemonkey.simplejavamail.TransportStrategy");
   def configuration = configClass.newInstance([
       host: "postfix", // hostname
       port: 25, // port
-      transportStrategy: Enum.valueOf(strategyClass, "SMTP_PLAIN"),
+      transportStrategy: findSmtpStrategy(),
       from: from,
       subjectPrefix: old.getSubjectPrefix()
   ]);


### PR DESCRIPTION
The newest version of the scm-mail-plugin requieres a new simple-java-mail dependency. Which changed the Enum of the Transport Strategy. The changes of this pr should handle these breaking changes.