### PR TITLE
Read local configs from DoguConfig instead of GlobalConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Read local configs from DoguConfig instead of GlobalConfig [#100]
+
 ## [3.5.0-1] 2024-10-10
 ### Changed
 - Upgrade SCM-Manager to version 3.5.0 ([Changelog](https://github.com/scm-manager/scm-manager/blob/3.5.0/CHANGELOG.md))

--- a/resources/var/tmp/scm/init.script.d/020-configuration.groovy
+++ b/resources/var/tmp/scm/init.script.d/020-configuration.groovy
@@ -24,12 +24,12 @@ config.setBaseUrl("https://${fqdn}/scm");
 def context = injector.getInstance(SCMContextProvider.class);
 
 // set plugin center url
-String pluginCenterUrl = ecoSystem.getGlobalConfig("plugin_center_url");
+String pluginCenterUrl = ecoSystem.getDoguConfig("plugin_center_url");
 if (pluginCenterUrl != null && !pluginCenterUrl.isEmpty()) {
   config.setPluginUrl(pluginCenterUrl);
 }
 
-String pluginCenterAuthenticationUrl = ecoSystem.getGlobalConfig("plugin_center_authentication_url");
+String pluginCenterAuthenticationUrl = ecoSystem.getDoguConfig("plugin_center_authentication_url");
 if (pluginCenterAuthenticationUrl != null) {
   if ("none".equalsIgnoreCase(pluginCenterAuthenticationUrl)) {
     println("deactivating plugin center authentication");
@@ -39,7 +39,7 @@ if (pluginCenterAuthenticationUrl != null) {
   }
 }
 
-String loginInfoUrl = ecoSystem.getGlobalConfig("login_info_url");
+String loginInfoUrl = ecoSystem.getDoguConfig("login_info_url");
 if (loginInfoUrl != null) {
     if ("none".equalsIgnoreCase(loginInfoUrl)) {
         println("deactivating login info");
@@ -49,7 +49,7 @@ if (loginInfoUrl != null) {
     }
 }
 
-String alertsUrl = ecoSystem.getGlobalConfig("alerts_url");
+String alertsUrl = ecoSystem.getDoguConfig("alerts_url");
 if (alertsUrl != null) {
     if ("none".equalsIgnoreCase(alertsUrl)) {
         println("deactivating alerts");
@@ -60,8 +60,8 @@ if (alertsUrl != null) {
 }
 
 // set release feed  url
-String disableReleaseFeed = ecoSystem.getGlobalConfig("disable_release_feed");
-String releaseFeedUrl = ecoSystem.getGlobalConfig("release_feed_url");
+String disableReleaseFeed = ecoSystem.getDoguConfig("disable_release_feed");
+String releaseFeedUrl = ecoSystem.getDoguConfig("release_feed_url");
 
 if (disableReleaseFeed != null && disableReleaseFeed.equalsIgnoreCase("true")) {
   config.setReleaseFeedUrl("");


### PR DESCRIPTION
Some values defined in the dogu.json are read from the global config instead of the dogu config. As a consequence default values has always been used.